### PR TITLE
Change namespace.

### DIFF
--- a/src/main/scala/net/scalax/cpoi/api/package.scala
+++ b/src/main/scala/net/scalax/cpoi/api/package.scala
@@ -1,0 +1,5 @@
+package net.scalax.cpoi
+
+import net.scalax.cpoi.utils.Alias
+
+package object api extends Alias

--- a/src/main/scala/net/scalax/cpoi/package.scala
+++ b/src/main/scala/net/scalax/cpoi/package.scala
@@ -1,5 +1,0 @@
-package net.scalax
-
-import net.scalax.cpoi.utils.Alias
-
-package object cpoi extends Alias

--- a/src/main/scala/net/scalax/cpoi/utils/Alias.scala
+++ b/src/main/scala/net/scalax/cpoi/utils/Alias.scala
@@ -8,7 +8,7 @@ import net.scalax.cpoi.rw.{
 
 trait Alias {
 
-  val CPoiUtils: CPoiUtils = new CPoiUtils {}
+  val CPoi: CPoi = new CPoi {}
 
   val readers: CellReadersImplicits = new CellReadersImplicits {}
   val immutableReaders: ImmutableCellReadersImplicits =

--- a/src/main/scala/net/scalax/cpoi/utils/CPoi.scala
+++ b/src/main/scala/net/scalax/cpoi/utils/CPoi.scala
@@ -18,7 +18,7 @@ import org.apache.poi.ss.usermodel.{Cell, CellStyle}
 import scala.util.{Failure, Try}
 import scala.collection.mutable.{Map => MutableMap}
 
-trait CPoiUtils {
+trait CPoi {
 
   def multiplySet(styleGen: StyleGen,
                   seq: Seq[(Cell, CellDataAbs)]): Try[StyleGen] = {

--- a/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookBlankCellTest.scala
+++ b/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookBlankCellTest.scala
@@ -3,7 +3,7 @@ package net.scalax.cpoi.test
 import java.util.Date
 
 import net.scalax.cpoi.exception.CellNotExistsException
-import net.scalax.cpoi._
+import net.scalax.cpoi.api._
 import org.apache.poi.hssf.usermodel.HSSFWorkbook
 import org.scalatest._
 

--- a/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookBlankCellTest.scala
+++ b/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookBlankCellTest.scala
@@ -15,7 +15,7 @@ class HSSFWorkbookBlankCellTest extends FlatSpec with Matchers {
     val sheet = workbook.createSheet("Sheet1")
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[String]
     wrap.isBlank should be(true)
     value.isRight should be(true)
@@ -28,7 +28,7 @@ class HSSFWorkbookBlankCellTest extends FlatSpec with Matchers {
     val sheet = workbook.createSheet("Sheet1")
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[Double]
     wrap.isBlank should be(true)
     value.isLeft should be(true)
@@ -41,7 +41,7 @@ class HSSFWorkbookBlankCellTest extends FlatSpec with Matchers {
     val sheet = workbook.createSheet("Sheet1")
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[Boolean]
     wrap.isBlank should be(true)
     value.isLeft should be(true)
@@ -54,7 +54,7 @@ class HSSFWorkbookBlankCellTest extends FlatSpec with Matchers {
     val sheet = workbook.createSheet("Sheet1")
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[Date]
     wrap.isBlank should be(true)
     value.isLeft should be(true)
@@ -67,7 +67,7 @@ class HSSFWorkbookBlankCellTest extends FlatSpec with Matchers {
     val sheet = workbook.createSheet("Sheet1")
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[String]
     wrap.isBlank should be(true)
     value.isRight should be(true)
@@ -80,7 +80,7 @@ class HSSFWorkbookBlankCellTest extends FlatSpec with Matchers {
     val sheet = workbook.createSheet("Sheet1")
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[String]
     wrap.isBlank should be(true)
     value.isLeft should be(true)
@@ -93,7 +93,7 @@ class HSSFWorkbookBlankCellTest extends FlatSpec with Matchers {
     val sheet = workbook.createSheet("Sheet1")
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[String]
     wrap.isBlank should be(true)
     value.isLeft should be(true)

--- a/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookBlankStringCellTest.scala
+++ b/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookBlankStringCellTest.scala
@@ -8,7 +8,7 @@ import net.scalax.cpoi.exception.{
   ExpectDateException,
   ExpectNumericCellException
 }
-import net.scalax.cpoi._
+import net.scalax.cpoi.api._
 import org.apache.poi.hssf.usermodel.HSSFWorkbook
 import org.scalatest._
 

--- a/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookBlankStringCellTest.scala
+++ b/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookBlankStringCellTest.scala
@@ -21,7 +21,7 @@ class HSSFWorkbookBlankStringCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue("    ")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[String]
     value.isRight should be(true)
     value.right.get should be("    ")
@@ -34,7 +34,7 @@ class HSSFWorkbookBlankStringCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue("    ")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[Double]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[ExpectNumericCellException] should be(true)
@@ -47,7 +47,7 @@ class HSSFWorkbookBlankStringCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue("    ")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[Boolean]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[ExpectBooleanCellException] should be(true)
@@ -60,7 +60,7 @@ class HSSFWorkbookBlankStringCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue("    ")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[Date]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[ExpectDateException] should be(true)
@@ -73,7 +73,7 @@ class HSSFWorkbookBlankStringCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue("    ")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[String]
     value.isRight should be(true)
     value.right.get should be("    ")
@@ -86,7 +86,7 @@ class HSSFWorkbookBlankStringCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue("    ")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[String]
     value.isRight should be(true)
     value.right.get should be("    ")
@@ -99,7 +99,7 @@ class HSSFWorkbookBlankStringCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue("    ")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[String]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[CellNotExistsException] should be(true)

--- a/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookBooleanFormulaCellTest.scala
+++ b/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookBooleanFormulaCellTest.scala
@@ -20,7 +20,7 @@ class HSSFWorkbookBooleanFormulaCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellFormula("3 > 2")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[String]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[ExpectStringCellException] should be(true)
@@ -33,7 +33,7 @@ class HSSFWorkbookBooleanFormulaCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellFormula("3 > 2")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[Double]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[ExpectNumericCellException] should be(true)
@@ -46,7 +46,7 @@ class HSSFWorkbookBooleanFormulaCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellFormula("3 > 2")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[Boolean]
     value.isRight should be(true)
     value.right.get should be(true)
@@ -59,7 +59,7 @@ class HSSFWorkbookBooleanFormulaCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellFormula("3 > 2")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[Date]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[ExpectDateException] should be(true)
@@ -72,7 +72,7 @@ class HSSFWorkbookBooleanFormulaCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellFormula("3 > 2")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[String]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[ExpectStringCellException] should be(true)
@@ -85,7 +85,7 @@ class HSSFWorkbookBooleanFormulaCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellFormula("3 > 2")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[String]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[ExpectStringCellException] should be(true)
@@ -98,7 +98,7 @@ class HSSFWorkbookBooleanFormulaCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellFormula("3 > 2")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[String]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[ExpectStringCellException] should be(true)

--- a/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookBooleanFormulaCellTest.scala
+++ b/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookBooleanFormulaCellTest.scala
@@ -2,7 +2,7 @@ package net.scalax.cpoi.test
 
 import java.util.Date
 
-import net.scalax.cpoi._
+import net.scalax.cpoi.api._
 import net.scalax.cpoi.exception.{
   ExpectDateException,
   ExpectNumericCellException,

--- a/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookEmptyStringCellTest.scala
+++ b/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookEmptyStringCellTest.scala
@@ -8,7 +8,7 @@ import net.scalax.cpoi.exception.{
   ExpectDateException,
   ExpectNumericCellException
 }
-import net.scalax.cpoi._
+import net.scalax.cpoi.api._
 import org.apache.poi.hssf.usermodel.HSSFWorkbook
 import org.scalatest._
 

--- a/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookEmptyStringCellTest.scala
+++ b/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookEmptyStringCellTest.scala
@@ -21,7 +21,7 @@ class HSSFWorkbookEmptyStringCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue("")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[String]
     value.isRight should be(true)
     value.right.get should be("")
@@ -34,7 +34,7 @@ class HSSFWorkbookEmptyStringCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue("")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[Double]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[ExpectNumericCellException] should be(true)
@@ -47,7 +47,7 @@ class HSSFWorkbookEmptyStringCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue("")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[Boolean]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[ExpectBooleanCellException] should be(true)
@@ -60,7 +60,7 @@ class HSSFWorkbookEmptyStringCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue("")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[Date]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[ExpectDateException] should be(true)
@@ -73,7 +73,7 @@ class HSSFWorkbookEmptyStringCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue("")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[String]
     value.isRight should be(true)
     value.right.get should be("")
@@ -86,7 +86,7 @@ class HSSFWorkbookEmptyStringCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue("")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[String]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[CellNotExistsException] should be(true)
@@ -99,7 +99,7 @@ class HSSFWorkbookEmptyStringCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue("")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[String]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[CellNotExistsException] should be(true)

--- a/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookFalseBooleanCellTest.scala
+++ b/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookFalseBooleanCellTest.scala
@@ -2,7 +2,7 @@ package net.scalax.cpoi.test
 
 import java.util.Date
 
-import net.scalax.cpoi._
+import net.scalax.cpoi.api._
 import net.scalax.cpoi.exception.{
   ExpectDateException,
   ExpectNumericCellException,

--- a/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookFalseBooleanCellTest.scala
+++ b/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookFalseBooleanCellTest.scala
@@ -20,7 +20,7 @@ class HSSFWorkbookFalseBooleanCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue(false)
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[String]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[ExpectStringCellException] should be(true)
@@ -33,7 +33,7 @@ class HSSFWorkbookFalseBooleanCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue(false)
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[Double]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[ExpectNumericCellException] should be(true)
@@ -46,7 +46,7 @@ class HSSFWorkbookFalseBooleanCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue(false)
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[Boolean]
     value.isRight should be(true)
     value.right.get should be(false)
@@ -59,7 +59,7 @@ class HSSFWorkbookFalseBooleanCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue(false)
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[Date]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[ExpectDateException] should be(true)
@@ -72,7 +72,7 @@ class HSSFWorkbookFalseBooleanCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue(false)
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[String]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[ExpectStringCellException] should be(true)
@@ -85,7 +85,7 @@ class HSSFWorkbookFalseBooleanCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue(false)
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[String]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[ExpectStringCellException] should be(true)
@@ -98,7 +98,7 @@ class HSSFWorkbookFalseBooleanCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue(false)
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[String]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[ExpectStringCellException] should be(true)

--- a/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookNotBlankStringCellTest.scala
+++ b/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookNotBlankStringCellTest.scala
@@ -7,7 +7,7 @@ import net.scalax.cpoi.exception.{
   ExpectDateException,
   ExpectNumericCellException
 }
-import net.scalax.cpoi._
+import net.scalax.cpoi.api._
 import org.apache.poi.hssf.usermodel.HSSFWorkbook
 import org.scalatest._
 

--- a/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookNotBlankStringCellTest.scala
+++ b/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookNotBlankStringCellTest.scala
@@ -20,7 +20,7 @@ class HSSFWorkbookNotBlankStringCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue("-123        ")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[String]
     value.isRight should be(true)
     value.right.get should be("-123        ")
@@ -33,7 +33,7 @@ class HSSFWorkbookNotBlankStringCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue("-123        ")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[Double]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[ExpectNumericCellException] should be(true)
@@ -46,7 +46,7 @@ class HSSFWorkbookNotBlankStringCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue("-123        ")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[Boolean]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[ExpectBooleanCellException] should be(true)
@@ -59,7 +59,7 @@ class HSSFWorkbookNotBlankStringCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue("-123        ")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[Date]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[ExpectDateException] should be(true)
@@ -72,7 +72,7 @@ class HSSFWorkbookNotBlankStringCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue("-123        ")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[String]
     value.isRight should be(true)
     value.right.get should be("-123        ")
@@ -85,7 +85,7 @@ class HSSFWorkbookNotBlankStringCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue("-123        ")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[String]
     value.isRight should be(true)
     value.right.get should be("-123        ")
@@ -98,7 +98,7 @@ class HSSFWorkbookNotBlankStringCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue("-123        ")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[String]
     value.isRight should be(true)
     value.right.get should be("-123")

--- a/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookNullCellTest.scala
+++ b/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookNullCellTest.scala
@@ -2,7 +2,7 @@ package net.scalax.cpoi.test
 
 import java.util.Date
 
-import net.scalax.cpoi._
+import net.scalax.cpoi.api._
 import net.scalax.cpoi.exception.CellNotExistsException
 import org.apache.poi.ss.usermodel.Cell
 import org.scalatest._

--- a/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookNullCellTest.scala
+++ b/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookNullCellTest.scala
@@ -11,7 +11,7 @@ class HSSFWorkbookNullCellTest extends FlatSpec with Matchers {
 
   "null cell" should "read as empty string by common string reader" in {
     import readers._
-    val wrap = CPoiUtils.wrapCell(null: Cell)
+    val wrap = CPoi.wrapCell(null: Cell)
     val value = wrap.tryValue[String]
     value.isRight should be(true)
     value.right.get should be("")
@@ -19,7 +19,7 @@ class HSSFWorkbookNullCellTest extends FlatSpec with Matchers {
 
   it should "throw exception when read by double reader" in {
     import readers._
-    val wrap = CPoiUtils.wrapCell(null: Cell)
+    val wrap = CPoi.wrapCell(null: Cell)
     val value = wrap.tryValue[Double]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[CellNotExistsException] should be(true)
@@ -27,7 +27,7 @@ class HSSFWorkbookNullCellTest extends FlatSpec with Matchers {
 
   it should "throw exception when read by boolean reader" in {
     import readers._
-    val wrap = CPoiUtils.wrapCell(null: Cell)
+    val wrap = CPoi.wrapCell(null: Cell)
     val value = wrap.tryValue[Boolean]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[CellNotExistsException] should be(true)
@@ -35,7 +35,7 @@ class HSSFWorkbookNullCellTest extends FlatSpec with Matchers {
 
   it should "throw exception when read by date reader" in {
     import readers._
-    val wrap = CPoiUtils.wrapCell(null: Cell)
+    val wrap = CPoi.wrapCell(null: Cell)
     val value = wrap.tryValue[Date]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[CellNotExistsException] should be(true)
@@ -43,7 +43,7 @@ class HSSFWorkbookNullCellTest extends FlatSpec with Matchers {
 
   it should "read as empty string by immutable string reader" in {
     import immutableReaders._
-    val wrap = CPoiUtils.wrapCell(null: Cell)
+    val wrap = CPoi.wrapCell(null: Cell)
     val value = wrap.tryValue[String]
     value.isRight should be(true)
     value.right.get should be("")
@@ -51,7 +51,7 @@ class HSSFWorkbookNullCellTest extends FlatSpec with Matchers {
 
   it should "throw exception when read by non empty string reader" in {
     implicit val ec = readers.nonEmptyStringReader
-    val wrap = CPoiUtils.wrapCell(null: Cell)
+    val wrap = CPoi.wrapCell(null: Cell)
     val value = wrap.tryValue[String]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[CellNotExistsException] should be(true)
@@ -59,7 +59,7 @@ class HSSFWorkbookNullCellTest extends FlatSpec with Matchers {
 
   it should "throw exception when read by non blank string reader" in {
     implicit val ec = readers.nonBlankStringReader
-    val wrap = CPoiUtils.wrapCell(null: Cell)
+    val wrap = CPoi.wrapCell(null: Cell)
     val value = wrap.tryValue[String]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[CellNotExistsException] should be(true)

--- a/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookNumbericCellTest1.scala
+++ b/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookNumbericCellTest1.scala
@@ -20,7 +20,7 @@ class HSSFWorkbookNumbericCellTest1 extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue(123.321)
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     wrap.cellType should be(Option(CellType.NUMERIC))
     val value = wrap.tryValue[String]
     wrap.cellType should be(Option(CellType.STRING))
@@ -35,7 +35,7 @@ class HSSFWorkbookNumbericCellTest1 extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue(123.321)
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[Double]
     value.isRight should be(true)
     value.right.get should be(123.321)
@@ -48,7 +48,7 @@ class HSSFWorkbookNumbericCellTest1 extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue(123.321)
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[Boolean]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[ExpectBooleanCellException] should be(true)
@@ -61,7 +61,7 @@ class HSSFWorkbookNumbericCellTest1 extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue(123.321)
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[Date]
     value.isRight should be(true)
     val calendar = Calendar.getInstance
@@ -76,7 +76,7 @@ class HSSFWorkbookNumbericCellTest1 extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue(123.321)
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     wrap.cellType should be(Option(CellType.NUMERIC))
     val value = wrap.tryValue[String]
     wrap.cellType should be(Option(CellType.NUMERIC))
@@ -91,7 +91,7 @@ class HSSFWorkbookNumbericCellTest1 extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue(123.321)
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     wrap.cellType should be(Option(CellType.NUMERIC))
     val value = wrap.tryValue[String]
     wrap.cellType should be(Option(CellType.STRING))
@@ -106,7 +106,7 @@ class HSSFWorkbookNumbericCellTest1 extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue(123.321)
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     wrap.cellType should be(Option(CellType.NUMERIC))
     val value = wrap.tryValue[String]
     wrap.cellType should be(Option(CellType.STRING))

--- a/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookNumbericCellTest1.scala
+++ b/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookNumbericCellTest1.scala
@@ -2,7 +2,7 @@ package net.scalax.cpoi.test
 
 import java.util.{Calendar, Date}
 
-import net.scalax.cpoi._
+import net.scalax.cpoi.api._
 import net.scalax.cpoi.exception.{
   ExpectBooleanCellException,
   ExpectStringCellException

--- a/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookNumbericCellTest2.scala
+++ b/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookNumbericCellTest2.scala
@@ -2,7 +2,7 @@ package net.scalax.cpoi.test
 
 import java.util.Date
 
-import net.scalax.cpoi._
+import net.scalax.cpoi.api._
 import net.scalax.cpoi.exception.{
   ExpectBooleanCellException,
   ExpectDateException,

--- a/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookNumbericCellTest2.scala
+++ b/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookNumbericCellTest2.scala
@@ -21,7 +21,7 @@ class HSSFWorkbookNumbericCellTest2 extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue(-123.321)
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     wrap.cellType should be(Option(CellType.NUMERIC))
     val value = wrap.tryValue[String]
     wrap.cellType should be(Option(CellType.STRING))
@@ -36,7 +36,7 @@ class HSSFWorkbookNumbericCellTest2 extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue(-123.321)
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[Double]
     value.isRight should be(true)
     value.right.get should be(-123.321)
@@ -49,7 +49,7 @@ class HSSFWorkbookNumbericCellTest2 extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue(-123.321)
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[Boolean]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[ExpectBooleanCellException] should be(true)
@@ -62,7 +62,7 @@ class HSSFWorkbookNumbericCellTest2 extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue(-123.321)
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[Date]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[ExpectDateException] should be(true)
@@ -75,7 +75,7 @@ class HSSFWorkbookNumbericCellTest2 extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue(-123.321)
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     wrap.cellType should be(Option(CellType.NUMERIC))
     val value = wrap.tryValue[String]
     wrap.cellType should be(Option(CellType.NUMERIC))
@@ -90,7 +90,7 @@ class HSSFWorkbookNumbericCellTest2 extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue(-123.321)
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     wrap.cellType should be(Option(CellType.NUMERIC))
     val value = wrap.tryValue[String]
     wrap.cellType should be(Option(CellType.STRING))
@@ -105,7 +105,7 @@ class HSSFWorkbookNumbericCellTest2 extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue(-123.321)
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     wrap.cellType should be(Option(CellType.NUMERIC))
     val value = wrap.tryValue[String]
     wrap.cellType should be(Option(CellType.STRING))

--- a/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookNumbricFormulaCellTest.scala
+++ b/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookNumbricFormulaCellTest.scala
@@ -2,7 +2,7 @@ package net.scalax.cpoi.test
 
 import java.util.{Calendar, Date}
 
-import net.scalax.cpoi._
+import net.scalax.cpoi.api._
 import net.scalax.cpoi.exception.{
   ExpectBooleanCellException,
   ExpectStringCellException

--- a/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookNumbricFormulaCellTest.scala
+++ b/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookNumbricFormulaCellTest.scala
@@ -20,7 +20,7 @@ class HSSFWorkbookNumbricFormulaCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellFormula("SUM(3, 4)")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     wrap.cellType should be(Option(CellType.FORMULA))
     val value = wrap.tryValue[String]
     wrap.cellType should be(Option(CellType.STRING))
@@ -35,7 +35,7 @@ class HSSFWorkbookNumbricFormulaCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellFormula("SUM(3, 4)")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[Double]
     value.isRight should be(true)
     value.right.get should be(7)
@@ -48,7 +48,7 @@ class HSSFWorkbookNumbricFormulaCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellFormula("SUM(3, 4)")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[Boolean]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[ExpectBooleanCellException] should be(true)
@@ -61,7 +61,7 @@ class HSSFWorkbookNumbricFormulaCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellFormula("SUM(3, 4)")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[Date]
     value.isRight should be(true)
     val calendar = Calendar.getInstance
@@ -76,7 +76,7 @@ class HSSFWorkbookNumbricFormulaCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellFormula("SUM(3, 4)")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     wrap.cellType should be(Option(CellType.FORMULA))
     val value = wrap.tryValue[String]
     wrap.cellType should be(Option(CellType.NUMERIC))
@@ -91,7 +91,7 @@ class HSSFWorkbookNumbricFormulaCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellFormula("SUM(3, 4)")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     wrap.cellType should be(Option(CellType.FORMULA))
     val value = wrap.tryValue[String]
     wrap.cellType should be(Option(CellType.STRING))
@@ -106,7 +106,7 @@ class HSSFWorkbookNumbricFormulaCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellFormula("SUM(3, 4)")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     wrap.cellType should be(Option(CellType.FORMULA))
     val value = wrap.tryValue[String]
     wrap.cellType should be(Option(CellType.STRING))

--- a/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookOptionReaderTest.scala
+++ b/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookOptionReaderTest.scala
@@ -15,7 +15,7 @@ class HSSFWorkbookOptionReaderTest extends FlatSpec with Matchers {
     val row = sheet.createRow(2)
     val cell = row.createCell(3)
     cell.setCellValue(testBlankStr)
-    val ccell = CPoiUtils.wrapCell(cell)
+    val ccell = CPoi.wrapCell(cell)
     val value = ccell.tryValue[Option[String]]
     value.isRight should be(true)
     value.right.get should be(Option(testBlankStr))
@@ -30,7 +30,7 @@ class HSSFWorkbookOptionReaderTest extends FlatSpec with Matchers {
     val row = sheet.createRow(2)
     val cell = row.createCell(3)
     cell.setCellValue(testBlankStr)
-    val ccell = CPoiUtils.wrapCell(cell)
+    val ccell = CPoi.wrapCell(cell)
     val value = ccell.tryValue[Option[String]]
     value.isRight should be(true)
     value.right.get should be(Option.empty)

--- a/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookOptionReaderTest.scala
+++ b/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookOptionReaderTest.scala
@@ -1,6 +1,6 @@
 package net.scalax.cpoi.test
 
-import net.scalax.cpoi._
+import net.scalax.cpoi.api._
 import org.apache.poi.hssf.usermodel.HSSFWorkbook
 import org.scalatest._
 

--- a/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookStringFormulaCellTest.scala
+++ b/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookStringFormulaCellTest.scala
@@ -22,7 +22,7 @@ class HSSFWorkbookStringFormulaCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellFormula(s"""CONCATENATE("a", "${testUTF8Str}")""")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[String]
     value.isRight should be(true)
     value.right.get should be(s"a${testUTF8Str}")
@@ -35,7 +35,7 @@ class HSSFWorkbookStringFormulaCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellFormula(s"""CONCATENATE("a", "${testUTF8Str}")""")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[Double]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[ExpectNumericCellException] should be(true)
@@ -48,7 +48,7 @@ class HSSFWorkbookStringFormulaCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellFormula(s"""CONCATENATE("a", "${testUTF8Str}")""")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[Boolean]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[ExpectBooleanCellException] should be(true)
@@ -61,7 +61,7 @@ class HSSFWorkbookStringFormulaCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellFormula(s"""CONCATENATE("a", "${testUTF8Str}")""")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[Date]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[ExpectDateException] should be(true)
@@ -74,7 +74,7 @@ class HSSFWorkbookStringFormulaCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellFormula(s"""CONCATENATE("a", "${testUTF8Str}")""")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[String]
     value.isRight should be(true)
     value.right.get should be(s"a${testUTF8Str}")
@@ -87,7 +87,7 @@ class HSSFWorkbookStringFormulaCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellFormula(s"""CONCATENATE("a", "${testUTF8Str}")""")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[String]
     value.isRight should be(true)
     value.right.get should be(s"a${testUTF8Str}")
@@ -100,7 +100,7 @@ class HSSFWorkbookStringFormulaCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellFormula(s"""CONCATENATE("a", "${testUTF8Str}")""")
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[String]
     value.isRight should be(true)
     value.right.get should be(

--- a/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookStringFormulaCellTest.scala
+++ b/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookStringFormulaCellTest.scala
@@ -7,7 +7,7 @@ import net.scalax.cpoi.exception.{
   ExpectDateException,
   ExpectNumericCellException
 }
-import net.scalax.cpoi._
+import net.scalax.cpoi.api._
 import org.apache.poi.hssf.usermodel.HSSFWorkbook
 import org.scalatest._
 

--- a/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookTrueBooleanCellTest.scala
+++ b/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookTrueBooleanCellTest.scala
@@ -2,7 +2,7 @@ package net.scalax.cpoi.test
 
 import java.util.Date
 
-import net.scalax.cpoi._
+import net.scalax.cpoi.api._
 import net.scalax.cpoi.exception.{
   ExpectDateException,
   ExpectNumericCellException,

--- a/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookTrueBooleanCellTest.scala
+++ b/src/test/scala/net/scalax/cpoi/read/HSSFWorkbookTrueBooleanCellTest.scala
@@ -20,7 +20,7 @@ class HSSFWorkbookTrueBooleanCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue(true)
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[String]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[ExpectStringCellException] should be(true)
@@ -33,7 +33,7 @@ class HSSFWorkbookTrueBooleanCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue(true)
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[Double]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[ExpectNumericCellException] should be(true)
@@ -46,7 +46,7 @@ class HSSFWorkbookTrueBooleanCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue(true)
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[Boolean]
     value.isRight should be(true)
     value.right.get should be(true)
@@ -59,7 +59,7 @@ class HSSFWorkbookTrueBooleanCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue(true)
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[Date]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[ExpectDateException] should be(true)
@@ -72,7 +72,7 @@ class HSSFWorkbookTrueBooleanCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue(true)
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[String]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[ExpectStringCellException] should be(true)
@@ -85,7 +85,7 @@ class HSSFWorkbookTrueBooleanCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue(true)
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[String]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[ExpectStringCellException] should be(true)
@@ -98,7 +98,7 @@ class HSSFWorkbookTrueBooleanCellTest extends FlatSpec with Matchers {
     val row = sheet.createRow(1)
     val cell = row.createCell(1)
     cell.setCellValue(true)
-    val wrap = CPoiUtils.wrapCell(cell)
+    val wrap = CPoi.wrapCell(cell)
     val value = wrap.tryValue[String]
     value.isLeft should be(true)
     value.left.get.isInstanceOf[ExpectStringCellException] should be(true)

--- a/src/test/scala/net/scalax/cpoi/write/HSSFWorkbookMemoryWriterTest.scala
+++ b/src/test/scala/net/scalax/cpoi/write/HSSFWorkbookMemoryWriterTest.scala
@@ -50,16 +50,16 @@ class HSSFWorkbookMemoryWriterTest extends FlatSpec with Matchers {
     val cells = (for (rowIndex <- (1 to 8000)) yield {
       val row = sheet.createRow(rowIndex + 2)
       List(
-        row.createCell(3) -> CPoiUtils
+        row.createCell(3) -> CPoi
           .wrapData(testUTF8Str)
           .addTransform(TextStyle, Locked(false)),
-        row.createCell(6) -> CPoiUtils
+        row.createCell(6) -> CPoi
           .wrapData(testDouble)
           .addTransform(DoubleStyle, Locked(true))
       )
     }).flatten.toList
-    val gen = CPoiUtils.newStyleGen
-    CPoiUtils.multiplySet(gen, cells): Try[StyleGen]
+    val gen = CPoi.newStyleGen
+    CPoi.multiplySet(gen, cells): Try[StyleGen]
 
     (for (rowIndex <- (1 to 8000)) yield {
       val row = sheet.getRow(rowIndex + 2)
@@ -91,16 +91,16 @@ class HSSFWorkbookMemoryWriterTest extends FlatSpec with Matchers {
     val cells = (for (rowIndex <- (1 to 8000)) yield {
       val row = sheet.createRow(rowIndex + 2)
       List(
-        row.createCell(3) -> CPoiUtils
+        row.createCell(3) -> CPoi
           .wrapData(testUTF8Str)
           .addTransform(TextStyle, Locked(false)),
-        row.createCell(6) -> CPoiUtils
+        row.createCell(6) -> CPoi
           .wrapData(testDouble)
           .addTransform(DoubleStyle, Locked(true))
       )
     }).flatten.toList
-    val gen = CPoiUtils.newMutableStyleGen
-    CPoiUtils.multiplySet(gen, cells): Unit
+    val gen = CPoi.newMutableStyleGen
+    CPoi.multiplySet(gen, cells): Unit
 
     (for (rowIndex <- (1 to 8000)) yield {
       val row = sheet.getRow(rowIndex + 2)
@@ -132,16 +132,16 @@ class HSSFWorkbookMemoryWriterTest extends FlatSpec with Matchers {
     val cells = (for (rowIndex <- (1 to 8000)) yield {
       val row = sheet.createRow(rowIndex + 2)
       List(
-        row.createCell(3) -> CPoiUtils
+        row.createCell(3) -> CPoi
           .wrapData(testUTF8Str)
           .addTransform(TextStyle, Locked(false)),
-        row.createCell(6) -> CPoiUtils
+        row.createCell(6) -> CPoi
           .wrapData(testDouble)
           .addTransform(DoubleStyle, Locked(true))
       )
     }).flatten.toList.toStream
-    val gen = CPoiUtils.newStyleGen
-    CPoiUtils.multiplySet(gen, cells): Try[StyleGen]
+    val gen = CPoi.newStyleGen
+    CPoi.multiplySet(gen, cells): Try[StyleGen]
 
     (for (rowIndex <- (1 to 8000)) yield {
       val row = sheet.getRow(rowIndex + 2)
@@ -173,16 +173,16 @@ class HSSFWorkbookMemoryWriterTest extends FlatSpec with Matchers {
     val cells = (for (rowIndex <- (1 to 8000)) yield {
       val row = sheet.createRow(rowIndex + 2)
       List(
-        row.createCell(3) -> CPoiUtils
+        row.createCell(3) -> CPoi
           .wrapData(testUTF8Str)
           .addTransform(TextStyle, Locked(false)),
-        row.createCell(6) -> CPoiUtils
+        row.createCell(6) -> CPoi
           .wrapData(testDouble)
           .addTransform(DoubleStyle, Locked(true))
       )
     }).flatten.toList.toStream
-    val gen = CPoiUtils.newMutableStyleGen
-    CPoiUtils.multiplySet(gen, cells): Unit
+    val gen = CPoi.newMutableStyleGen
+    CPoi.multiplySet(gen, cells): Unit
 
     (for (rowIndex <- (1 to 8000)) yield {
       val row = sheet.getRow(rowIndex + 2)
@@ -222,14 +222,14 @@ class HSSFWorkbookMemoryWriterTest extends FlatSpec with Matchers {
     val poiCell4 = sheet.createRow(1).createCell(4)
 
     val cells = List(
-      poiCell1 -> CPoiUtils.wrapData(Option.empty[String]),
-      poiCell2 -> CPoiUtils.wrapData(Option.empty[Double]),
-      poiCell3 -> CPoiUtils.wrapData(Option.empty[Boolean]),
-      poiCell4 -> CPoiUtils.wrapData(Option.empty[Date])
+      poiCell1 -> CPoi.wrapData(Option.empty[String]),
+      poiCell2 -> CPoi.wrapData(Option.empty[Double]),
+      poiCell3 -> CPoi.wrapData(Option.empty[Boolean]),
+      poiCell4 -> CPoi.wrapData(Option.empty[Date])
     )
 
-    val gen = CPoiUtils.newStyleGen
-    CPoiUtils.multiplySet(gen, cells): Try[StyleGen]
+    val gen = CPoi.newStyleGen
+    CPoi.multiplySet(gen, cells): Try[StyleGen]
 
     poiCell1.getCellTypeEnum should be(CellType.BLANK)
     poiCell2.getCellTypeEnum should be(CellType.BLANK)
@@ -248,9 +248,9 @@ class HSSFWorkbookMemoryWriterTest extends FlatSpec with Matchers {
       sheet.createRow(i).createCell(1)
     }
 
-    val cellData = CPoiUtils.wrapData("2333").addTransform(TextStyle)
+    val cellData = CPoi.wrapData("2333").addTransform(TextStyle)
     val cellDataList = (1 to 1000).map(_ => cellData)
-    val gen = CPoiUtils.newStyleGen
+    val gen = CPoi.newStyleGen
 
     val tuple2List = poiCells
       .zip(cellDataList)
@@ -260,7 +260,7 @@ class HSSFWorkbookMemoryWriterTest extends FlatSpec with Matchers {
         case (item, _)                  => item
       }
 
-    CPoiUtils.multiplySet(gen, tuple2List): Try[StyleGen]
+    CPoi.multiplySet(gen, tuple2List): Try[StyleGen]
 
     poiCells(600).getCellTypeEnum should be(CellType.STRING)
     poiCells(601).getCellTypeEnum should be(CellType.STRING)
@@ -279,9 +279,9 @@ class HSSFWorkbookMemoryWriterTest extends FlatSpec with Matchers {
       sheet.createRow(i).createCell(1)
     }
 
-    val cellData = CPoiUtils.wrapData("2333").addTransform(TextStyle)
+    val cellData = CPoi.wrapData("2333").addTransform(TextStyle)
     val cellDataList = (1 to 1000).map(_ => cellData)
-    val gen = CPoiUtils.newMutableStyleGen
+    val gen = CPoi.newMutableStyleGen
 
     val tuple2List = poiCells
       .zip(cellDataList)
@@ -291,7 +291,7 @@ class HSSFWorkbookMemoryWriterTest extends FlatSpec with Matchers {
         case (item, _)                  => item
       }
 
-    CPoiUtils.multiplySet(gen, tuple2List): Try[CPoiDone]
+    CPoi.multiplySet(gen, tuple2List): Try[CPoiDone]
 
     poiCells(600).getCellTypeEnum should be(CellType.STRING)
     poiCells(601).getCellTypeEnum should be(CellType.STRING)

--- a/src/test/scala/net/scalax/cpoi/write/HSSFWorkbookMemoryWriterTest.scala
+++ b/src/test/scala/net/scalax/cpoi/write/HSSFWorkbookMemoryWriterTest.scala
@@ -2,7 +2,7 @@ package net.scalax.cpoi.test
 
 import java.util.Date
 
-import net.scalax.cpoi._
+import net.scalax.cpoi.api._
 import org.apache.poi.hssf.usermodel.HSSFWorkbook
 import org.apache.poi.ss.usermodel.{CellStyle, CellType, Workbook}
 import org.scalatest._


### PR DESCRIPTION
This change is to avoid the namespace pollution sine `utils` package and so on is under package `net.scalax.cpoi._`